### PR TITLE
[Feature] Firestore Link CRUD 구현

### DIFF
--- a/Mark-In/Sources/Data/DTOs/LinkDTO.swift
+++ b/Mark-In/Sources/Data/DTOs/LinkDTO.swift
@@ -1,0 +1,19 @@
+//
+//  LinkDTO.swift
+//  Mark-In
+//
+//  Created by 이정동 on 4/20/25.
+//
+
+import Foundation
+
+struct LinkDTO: Codable {
+  var id: String
+  var url: String
+  var title: String
+  var thumbnailUrl: String?
+  var faviconUrl: String?
+  var createdBy: Date
+  var lastAccessedAt: Date?
+  var folderId: String?
+}

--- a/Mark-In/Sources/Data/DTOs/LinkDTO.swift
+++ b/Mark-In/Sources/Data/DTOs/LinkDTO.swift
@@ -16,4 +16,28 @@ struct LinkDTO: Codable {
   var createdBy: Date
   var lastAccessedAt: Date?
   var folderId: String?
+  
+  init(_ link: Link) {
+    self.id = link.id
+    self.url = link.url
+    self.title = link.title
+    self.thumbnailUrl = link.thumbnailUrl
+    self.faviconUrl = link.faviconUrl
+    self.createdBy = link.createdBy
+    self.lastAccessedAt = link.lastAccessedAt
+    self.folderId = link.folderId
+  }
+  
+  func toEntity() -> Link {
+    Link(
+      id: self.id,
+      url: self.url,
+      title: self.title,
+      thumbnailUrl: self.thumbnailUrl,
+      faviconUrl: self.faviconUrl,
+      createdBy: self.createdBy,
+      lastAccessedAt: self.lastAccessedAt,
+      folderId: self.folderId
+    )
+  }
 }

--- a/Mark-In/Sources/Data/DTOs/LinkDTO.swift
+++ b/Mark-In/Sources/Data/DTOs/LinkDTO.swift
@@ -10,7 +10,7 @@ import Foundation
 struct LinkDTO: Codable {
   var id: String
   var url: String
-  var title: String
+  var title: String?
   var thumbnailUrl: String?
   var faviconUrl: String?
   var createdBy: Date

--- a/Mark-In/Sources/Data/Repositories/LinkRepositoryImpl.swift
+++ b/Mark-In/Sources/Data/Repositories/LinkRepositoryImpl.swift
@@ -16,9 +16,7 @@ struct LinkRepositoryImpl: LinkRepository {
   func createLink(_ link: Link) throws -> Link {
     /// 1. Link 문서 참조 생성
     // TODO: 후에 testUser를 실제 로그인 된 유저로 변경 예정
-    let linkDocRef = db
-      .collection("users").document("testUser")
-      .collection("links").document()
+    let linkDocRef = db.collection("users/testUser/links").document()
     
     /// 2. Entity를 DTO로 변환 및 새로 생성된 문서 ID를 프로퍼티에 저장
     var linkDTO = LinkDTO(link)
@@ -34,9 +32,7 @@ struct LinkRepositoryImpl: LinkRepository {
   func fetchAllLinks() async throws -> [Link] {
     /// 1. Links 컬렉션 참조 생성
     // TODO: 후에 testUser를 실제 로그인 된 유저로 변경 예정
-    let linkColRef = db
-      .collection("users").document("testUser")
-      .collection("links")
+    let linkColRef = db.collection("users/testUser/links")
     
     /// 2. 컬렉션의 모든 문서 가져오기
     let snapshot = try await linkColRef.getDocuments()
@@ -50,9 +46,7 @@ struct LinkRepositoryImpl: LinkRepository {
   func updateLink(_ link: Link) throws {
     /// 1. Link 문서 참조 생성
     // TODO: 후에 testUser를 실제 로그인 된 유저로 변경 예정
-    let linkDocRef = db
-      .collection("users").document("testUser")
-      .collection("links").document(link.id)
+    let linkDocRef = db.document("users/testUser/links/\(link.id)")
     
     /// 2. Entity를 DTO로 변환
     let linkDTO = LinkDTO(link)
@@ -64,9 +58,7 @@ struct LinkRepositoryImpl: LinkRepository {
   func deleteLink(_ link: Link) async throws {
     /// 1. Link 문서 참조 생성
     // TODO: 후에 testUser를 실제 로그인 된 유저로 변경 예정
-    let linkDocRef = db
-      .collection("users").document("testUser")
-      .collection("links").document(link.id)
+    let linkDocRef = db.document("users/testUser/links/\(link.id)")
     
     /// 2. Link 삭제
     try await linkDocRef.delete()

--- a/Mark-In/Sources/Data/Repositories/LinkRepositoryImpl.swift
+++ b/Mark-In/Sources/Data/Repositories/LinkRepositoryImpl.swift
@@ -1,0 +1,74 @@
+//
+//  LinkRepositoryImpl.swift
+//  Mark-In
+//
+//  Created by 이정동 on 4/21/25.
+//
+
+import Foundation
+
+import FirebaseFirestore
+
+struct LinkRepositoryImpl: LinkRepository {
+  
+  private let db = Firestore.firestore()
+  
+  func createLink(_ link: Link) throws -> Link {
+    /// 1. Link 문서 참조 생성
+    // TODO: 후에 testUser를 실제 로그인 된 유저로 변경 예정
+    let linkDocRef = db
+      .collection("users").document("testUser")
+      .collection("links").document()
+    
+    /// 2. Entity를 DTO로 변환 및 새로 생성된 문서 ID를 프로퍼티에 저장
+    var linkDTO = LinkDTO(link)
+    linkDTO.id = linkDocRef.documentID
+    
+    /// 3. Firestore에 추가
+    try linkDocRef.setData(from: linkDTO)
+    
+    /// 4. DocumentID 업데이트 된 LinkEntity로 리턴
+    return linkDTO.toEntity()
+  }
+  
+  func fetchAllLinks() async throws -> [Link] {
+    /// 1. Links 컬렉션 참조 생성
+    // TODO: 후에 testUser를 실제 로그인 된 유저로 변경 예정
+    let linkColRef = db
+      .collection("users").document("testUser")
+      .collection("links")
+    
+    /// 2. 컬렉션의 모든 문서 가져오기
+    let snapshot = try await linkColRef.getDocuments()
+    
+    /// 3. 문서를 DTO로 변환 후 다시 Entity로 변환
+    return snapshot.documents.compactMap {
+      try? $0.data(as: LinkDTO.self).toEntity()
+    }
+  }
+  
+  func updateLink(_ link: Link) throws {
+    /// 1. Link 문서 참조 생성
+    // TODO: 후에 testUser를 실제 로그인 된 유저로 변경 예정
+    let linkDocRef = db
+      .collection("users").document("testUser")
+      .collection("links").document(link.id)
+    
+    /// 2. Entity를 DTO로 변환
+    let linkDTO = LinkDTO(link)
+    
+    /// 3. 업데이트
+    try linkDocRef.setData(from: linkDTO)
+  }
+  
+  func deleteLink(_ link: Link) async throws {
+    /// 1. Link 문서 참조 생성
+    // TODO: 후에 testUser를 실제 로그인 된 유저로 변경 예정
+    let linkDocRef = db
+      .collection("users").document("testUser")
+      .collection("links").document(link.id)
+    
+    /// 2. Link 삭제
+    try await linkDocRef.delete()
+  }
+}

--- a/Mark-In/Sources/Data/Repositories/LinkRepositoryImpl.swift
+++ b/Mark-In/Sources/Data/Repositories/LinkRepositoryImpl.swift
@@ -11,9 +11,11 @@ import FirebaseFirestore
 
 struct LinkRepositoryImpl: LinkRepository {
   
+  typealias VoidCheckedContinuation = CheckedContinuation<Void, any Error>
+  
   private let db = Firestore.firestore()
   
-  func createLink(_ link: Link) throws -> Link {
+  func createLink(_ link: Link) async throws -> Link {
     /// 1. Link 문서 참조 생성
     // TODO: 후에 testUser를 실제 로그인 된 유저로 변경 예정
     let linkDocRef = db.collection("users/testUser/links").document()
@@ -23,7 +25,16 @@ struct LinkRepositoryImpl: LinkRepository {
     linkDTO.id = linkDocRef.documentID
     
     /// 3. Firestore에 추가
-    try linkDocRef.setData(from: linkDTO)
+    try await withCheckedThrowingContinuation { (continuation: VoidCheckedContinuation) in
+      do {
+        try linkDocRef.setData(from: linkDTO) { error in
+          if let error { continuation.resume(throwing: error) }
+          else { continuation.resume(returning: ()) }
+        }
+      } catch {
+        continuation.resume(throwing: error)
+      }
+    }
     
     /// 4. DocumentID 업데이트 된 LinkEntity로 리턴
     return linkDTO.toEntity()
@@ -43,7 +54,7 @@ struct LinkRepositoryImpl: LinkRepository {
     }
   }
   
-  func updateLink(_ link: Link) throws {
+  func updateLink(_ link: Link) async throws {
     /// 1. Link 문서 참조 생성
     // TODO: 후에 testUser를 실제 로그인 된 유저로 변경 예정
     let linkDocRef = db.document("users/testUser/links/\(link.id)")
@@ -52,7 +63,16 @@ struct LinkRepositoryImpl: LinkRepository {
     let linkDTO = LinkDTO(link)
     
     /// 3. 업데이트
-    try linkDocRef.setData(from: linkDTO)
+    try await withCheckedThrowingContinuation { (continuation: VoidCheckedContinuation) in
+      do {
+        try linkDocRef.setData(from: linkDTO) { error in
+          if let error { continuation.resume(throwing: error) }
+          else { continuation.resume(returning: ()) }
+        }
+      } catch {
+        continuation.resume(throwing: error)
+      }
+    }
   }
   
   func deleteLink(_ link: Link) async throws {

--- a/Mark-In/Sources/Domain/Entities/Link.swift
+++ b/Mark-In/Sources/Domain/Entities/Link.swift
@@ -1,0 +1,19 @@
+//
+//  Link.swift
+//  Mark-In
+//
+//  Created by 이정동 on 4/20/25.
+//
+
+import Foundation
+
+struct Link {
+  var id: String
+  var url: String
+  var title: String
+  var thumbnailUrl: String?
+  var faviconUrl: String?
+  var createdBy: Date
+  var lastAccessedAt: Date?
+  var folderId: String?
+}

--- a/Mark-In/Sources/Domain/Entities/Link.swift
+++ b/Mark-In/Sources/Domain/Entities/Link.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 struct Link {
-  var id: String
+  var id: String = ""
   var url: String
-  var title: String
+  var title: String?
   var thumbnailUrl: String?
   var faviconUrl: String?
-  var createdBy: Date
+  var createdBy: Date = .now
   var lastAccessedAt: Date?
   var folderId: String?
 }

--- a/Mark-In/Sources/Domain/Interfaces/LinkRepository.swift
+++ b/Mark-In/Sources/Domain/Interfaces/LinkRepository.swift
@@ -1,0 +1,15 @@
+//
+//  LinkRepository.swift
+//  Mark-In
+//
+//  Created by 이정동 on 4/20/25.
+//
+
+import Foundation
+
+protocol LinkRepository {
+  func createLink(_ link: Link) throws -> Link
+  func fetchAllLinks() async throws -> [Link]
+  func updateLink(_ link: Link) throws
+  func deleteLink(_ link: Link) async throws
+}

--- a/Mark-In/Sources/Domain/Interfaces/LinkRepository.swift
+++ b/Mark-In/Sources/Domain/Interfaces/LinkRepository.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 protocol LinkRepository {
-  func createLink(_ link: Link) throws -> Link
+  func createLink(_ link: Link) async throws -> Link
   func fetchAllLinks() async throws -> [Link]
-  func updateLink(_ link: Link) throws
+  func updateLink(_ link: Link) async throws
   func deleteLink(_ link: Link) async throws
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- 이슈 번호를 작성해 주세요 -->
<!-- ex) - close #1 -->
- close #8 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요(이미지 첨부 가능) --> 
- Link 데이터를 Firestore에 저장하기 위한 CRUD 로직을 구현했습니다.

## 🎨 스크린샷

## 💬 추가 설명
<!-- 추가적으로 설명할 부분이 있다면 작성해 주세요 -->

### 특정 조건에 해당하는 링크 리스트 가져오기
원래는 Firebase에서 즐겨찾기한 링크 불러오기, 읽지 않은 링크 불러오기 로직을 추가로 구현하려고 했지만, 앱 진입 시 전체 링크 데이터를 먼저 불러오기 때문에 이 데이터를 기반으로 로컬에서 필터링하는 방식으로 구현했습니다.

다만, 저장된 링크가 많아질 경우 전체 데이터를 한번에 불러오는 것이 부담될 수 있기 때문에 이후에는 페이징이 필요할 것으로 예상됩니다.

이와 함께 특정 조건(즐겨찾기, 읽지 않음 등)에 해당하는 링크만 가져오는 서버 쿼리 방식도 필요할 것으로 예상됩니다.
그 이유는, 초기 로딩 시 제한된 범위의 데이터만 불러오고 이를 기반으로 필터링하게 되면, 실제로 조건에 해당하는 모든 링크가 아닌, 현재 로컬에 존재하는 일부 데이터만 보여지게 되기 때문입니다.
