### PR TITLE
[Test] DTO CodingKey와 FirestoreFieldKey 간 매핑 일치 여부 테스트 코드 작성

### DIFF
--- a/Mark-In-Tests/ValidationsTests/DTOFieldKeyMappingTests.swift
+++ b/Mark-In-Tests/ValidationsTests/DTOFieldKeyMappingTests.swift
@@ -11,14 +11,14 @@ import Testing
 struct DTOFieldKeyMappingTests {
   
   @Test
-  func testCodingKeys_shouldMatchFirestoreFieldKeys_inFolderDTO() async throws {
+  func test_FolderDTO의_CodingKey와_FirestoreFieldKey가_일치해야_한다() async throws {
     #expect(FolderDTO.CodingKeys.id.rawValue == FirestoreFieldKey.Folder.id)
     #expect(FolderDTO.CodingKeys.name.rawValue == FirestoreFieldKey.Folder.name)
     #expect(FolderDTO.CodingKeys.createdAt.rawValue == FirestoreFieldKey.Folder.createdAt)
   }
   
   @Test
-  func testCodingKeys_shouldMatchFirestoreFieldKeys_inWebLinkDTO() async throws {
+  func test_WebLinkDTO의_CodingKey와_FirestoreFieldKey가_일치해야_한다() async throws {
     #expect(WebLinkDTO.CodingKeys.id.rawValue == FirestoreFieldKey.Link.id)
     #expect(WebLinkDTO.CodingKeys.url.rawValue == FirestoreFieldKey.Link.url)
     #expect(WebLinkDTO.CodingKeys.title.rawValue == FirestoreFieldKey.Link.title)

--- a/Mark-In-Tests/ValidationsTests/DTOFieldKeyMappingTests.swift
+++ b/Mark-In-Tests/ValidationsTests/DTOFieldKeyMappingTests.swift
@@ -1,0 +1,32 @@
+//
+//  Mark_In_Tests.swift
+//  Mark-In-Tests
+//
+//  Created by 이정동 on 6/4/25.
+//
+
+import Testing
+@testable import Mark_In
+
+struct DTOFieldKeyMappingTests {
+  
+  @Test
+  func testCodingKeys_shouldMatchFirestoreFieldKeys_inFolderDTO() async throws {
+    #expect(FolderDTO.CodingKeys.id.rawValue == FirestoreFieldKey.Folder.id)
+    #expect(FolderDTO.CodingKeys.name.rawValue == FirestoreFieldKey.Folder.name)
+    #expect(FolderDTO.CodingKeys.createdAt.rawValue == FirestoreFieldKey.Folder.createdAt)
+  }
+  
+  @Test
+  func testCodingKeys_shouldMatchFirestoreFieldKeys_inWebLinkDTO() async throws {
+    #expect(WebLinkDTO.CodingKeys.id.rawValue == FirestoreFieldKey.Link.id)
+    #expect(WebLinkDTO.CodingKeys.url.rawValue == FirestoreFieldKey.Link.url)
+    #expect(WebLinkDTO.CodingKeys.title.rawValue == FirestoreFieldKey.Link.title)
+    #expect(WebLinkDTO.CodingKeys.thumbnailUrl.rawValue == FirestoreFieldKey.Link.thumbnailUrl)
+    #expect(WebLinkDTO.CodingKeys.faviconUrl.rawValue == FirestoreFieldKey.Link.faviconUrl)
+    #expect(WebLinkDTO.CodingKeys.isPinned.rawValue == FirestoreFieldKey.Link.isPinned)
+    #expect(WebLinkDTO.CodingKeys.createdAt.rawValue == FirestoreFieldKey.Link.createdAt)
+    #expect(WebLinkDTO.CodingKeys.lastAccessedAt.rawValue == FirestoreFieldKey.Link.lastAccessedAt)
+    #expect(WebLinkDTO.CodingKeys.folderID.rawValue == FirestoreFieldKey.Link.folderID)
+  }
+}

--- a/Mark-In-Tests/ValidationsTests/DTOFieldKeyMappingTests.swift
+++ b/Mark-In-Tests/ValidationsTests/DTOFieldKeyMappingTests.swift
@@ -6,27 +6,41 @@
 //
 
 import Testing
+import TestSupport
+
 @testable import Mark_In
 
-struct DTOFieldKeyMappingTests {
+struct DTOFieldKeyMappingTests: BaseTestCase {
   
   @Test
   func test_FolderDTO의_CodingKey와_FirestoreFieldKey가_일치해야_한다() async throws {
-    #expect(FolderDTO.CodingKeys.id.rawValue == FirestoreFieldKey.Folder.id)
-    #expect(FolderDTO.CodingKeys.name.rawValue == FirestoreFieldKey.Folder.name)
-    #expect(FolderDTO.CodingKeys.createdAt.rawValue == FirestoreFieldKey.Folder.createdAt)
+    given { }
+    
+    when { }
+    
+    then {
+      #expect(FolderDTO.CodingKeys.id.rawValue == FirestoreFieldKey.Folder.id)
+      #expect(FolderDTO.CodingKeys.name.rawValue == FirestoreFieldKey.Folder.name)
+      #expect(FolderDTO.CodingKeys.createdAt.rawValue == FirestoreFieldKey.Folder.createdAt)
+    }
   }
   
   @Test
   func test_WebLinkDTO의_CodingKey와_FirestoreFieldKey가_일치해야_한다() async throws {
-    #expect(WebLinkDTO.CodingKeys.id.rawValue == FirestoreFieldKey.Link.id)
-    #expect(WebLinkDTO.CodingKeys.url.rawValue == FirestoreFieldKey.Link.url)
-    #expect(WebLinkDTO.CodingKeys.title.rawValue == FirestoreFieldKey.Link.title)
-    #expect(WebLinkDTO.CodingKeys.thumbnailUrl.rawValue == FirestoreFieldKey.Link.thumbnailUrl)
-    #expect(WebLinkDTO.CodingKeys.faviconUrl.rawValue == FirestoreFieldKey.Link.faviconUrl)
-    #expect(WebLinkDTO.CodingKeys.isPinned.rawValue == FirestoreFieldKey.Link.isPinned)
-    #expect(WebLinkDTO.CodingKeys.createdAt.rawValue == FirestoreFieldKey.Link.createdAt)
-    #expect(WebLinkDTO.CodingKeys.lastAccessedAt.rawValue == FirestoreFieldKey.Link.lastAccessedAt)
-    #expect(WebLinkDTO.CodingKeys.folderID.rawValue == FirestoreFieldKey.Link.folderID)
+    given { }
+    
+    when { }
+    
+    then {
+      #expect(WebLinkDTO.CodingKeys.id.rawValue == FirestoreFieldKey.Link.id)
+      #expect(WebLinkDTO.CodingKeys.url.rawValue == FirestoreFieldKey.Link.url)
+      #expect(WebLinkDTO.CodingKeys.title.rawValue == FirestoreFieldKey.Link.title)
+      #expect(WebLinkDTO.CodingKeys.thumbnailUrl.rawValue == FirestoreFieldKey.Link.thumbnailUrl)
+      #expect(WebLinkDTO.CodingKeys.faviconUrl.rawValue == FirestoreFieldKey.Link.faviconUrl)
+      #expect(WebLinkDTO.CodingKeys.isPinned.rawValue == FirestoreFieldKey.Link.isPinned)
+      #expect(WebLinkDTO.CodingKeys.createdAt.rawValue == FirestoreFieldKey.Link.createdAt)
+      #expect(WebLinkDTO.CodingKeys.lastAccessedAt.rawValue == FirestoreFieldKey.Link.lastAccessedAt)
+      #expect(WebLinkDTO.CodingKeys.folderID.rawValue == FirestoreFieldKey.Link.folderID)
+    }
   }
 }

--- a/Mark-In.xcodeproj/project.pbxproj
+++ b/Mark-In.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		57664F242DEEB2A100CA8D68 /* LinkMetadataKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 57664F1C2DEDCDCB00CA8D68 /* LinkMetadataKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		57664F252DEEB2A100CA8D68 /* LinkMetadataKitInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57664F1E2DEDCDCB00CA8D68 /* LinkMetadataKitInterface.framework */; };
 		57664F262DEEB2A100CA8D68 /* LinkMetadataKitInterface.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 57664F1E2DEDCDCB00CA8D68 /* LinkMetadataKitInterface.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		57664FE42DF2C0B900CA8D68 /* TestSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57664FB62DF2BF5900CA8D68 /* TestSupport.framework */; };
+		57664FE52DF2C0B900CA8D68 /* TestSupport.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 57664FB62DF2BF5900CA8D68 /* TestSupport.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		57944D0C2DC52AEF00EF3D9A /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 57944D0B2DC52AEF00EF3D9A /* GoogleSignIn */; };
 		57AC56A82DA5120600BA84BD /* Util.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57AC56732DA511E900BA84BD /* Util.framework */; };
 		57AC56A92DA5120600BA84BD /* Util.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 57AC56732DA511E900BA84BD /* Util.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -69,6 +71,13 @@
 			remoteGlobalIDString = 57BFD8C22DA4E19600648AD4;
 			remoteInfo = "Mark-In";
 		};
+		57664FB52DF2BF5900CA8D68 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 57664FB12DF2BF5900CA8D68 /* TestSupport.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 57664FA72DF2BF5800CA8D68;
+			remoteInfo = TestSupport;
+		};
 		57AC56722DA511E900BA84BD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 57AC53092DA4FC1800BA84BD /* Util.xcodeproj */;
@@ -79,6 +88,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		57664FE62DF2C0B900CA8D68 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				57664FE52DF2C0B900CA8D68 /* TestSupport.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		57AC55452DA507EC00BA84BD /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -101,6 +121,7 @@
 		57588CE42DD9B4D500DBD9A7 /* AppDI.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = AppDI.xcodeproj; path = AppDI/AppDI.xcodeproj; sourceTree = "<group>"; };
 		57606D652DD63B14005EBE3D /* ReducerKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ReducerKit.xcodeproj; path = ReducerKit/ReducerKit.xcodeproj; sourceTree = "<group>"; };
 		57664F682DF03A9000CA8D68 /* Mark-In-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Mark-In-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		57664FB12DF2BF5900CA8D68 /* TestSupport.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = TestSupport.xcodeproj; path = TestSupport/TestSupport.xcodeproj; sourceTree = "<group>"; };
 		57AC52EF2DA4FBC900BA84BD /* DesignSystem.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DesignSystem.xcodeproj; path = DesignSystem/DesignSystem.xcodeproj; sourceTree = "<group>"; };
 		57AC53092DA4FC1800BA84BD /* Util.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Util.xcodeproj; path = Util/Util.xcodeproj; sourceTree = "<group>"; };
 		57AC53232DA4FC4900BA84BD /* LinkMetadataKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = LinkMetadataKit.xcodeproj; path = LinkMetadataKit/LinkMetadataKit.xcodeproj; sourceTree = "<group>"; };
@@ -140,6 +161,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				57664FE42DF2C0B900CA8D68 /* TestSupport.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -176,6 +198,14 @@
 			isa = PBXGroup;
 			children = (
 				57588CE92DD9B4D600DBD9A7 /* AppDI.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		57664FB22DF2BF5900CA8D68 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				57664FB62DF2BF5900CA8D68 /* TestSupport.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -218,6 +248,7 @@
 		57AC56602DA511AF00BA84BD /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				57664FB12DF2BF5900CA8D68 /* TestSupport.xcodeproj */,
 				57AC53092DA4FC1800BA84BD /* Util.xcodeproj */,
 			);
 			path = Shared;
@@ -264,6 +295,7 @@
 				57664F642DF03A9000CA8D68 /* Sources */,
 				57664F652DF03A9000CA8D68 /* Frameworks */,
 				57664F662DF03A9000CA8D68 /* Resources */,
+				57664FE62DF2C0B900CA8D68 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -361,6 +393,10 @@
 					ProjectRef = 57606D652DD63B14005EBE3D /* ReducerKit.xcodeproj */;
 				},
 				{
+					ProductGroup = 57664FB22DF2BF5900CA8D68 /* Products */;
+					ProjectRef = 57664FB12DF2BF5900CA8D68 /* TestSupport.xcodeproj */;
+				},
+				{
 					ProductGroup = 57AC566F2DA511E900BA84BD /* Products */;
 					ProjectRef = 57AC53092DA4FC1800BA84BD /* Util.xcodeproj */;
 				},
@@ -407,6 +443,13 @@
 			fileType = wrapper.framework;
 			path = LinkMetadataKitInterface.framework;
 			remoteRef = 57664F1D2DEDCDCB00CA8D68 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		57664FB62DF2BF5900CA8D68 /* TestSupport.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = TestSupport.framework;
+			remoteRef = 57664FB52DF2BF5900CA8D68 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		57AC56732DA511E900BA84BD /* Util.framework */ = {

--- a/Mark-In.xcodeproj/project.pbxproj
+++ b/Mark-In.xcodeproj/project.pbxproj
@@ -62,6 +62,13 @@
 			remoteGlobalIDString = 57AC54A62DA503DE00BA84BD;
 			remoteInfo = LinkMetadataKitInterface;
 		};
+		57664F6C2DF03A9000CA8D68 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 57BFD8BB2DA4E19600648AD4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 57BFD8C22DA4E19600648AD4;
+			remoteInfo = "Mark-In";
+		};
 		57AC56722DA511E900BA84BD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 57AC53092DA4FC1800BA84BD /* Util.xcodeproj */;
@@ -93,6 +100,7 @@
 /* Begin PBXFileReference section */
 		57588CE42DD9B4D500DBD9A7 /* AppDI.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = AppDI.xcodeproj; path = AppDI/AppDI.xcodeproj; sourceTree = "<group>"; };
 		57606D652DD63B14005EBE3D /* ReducerKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ReducerKit.xcodeproj; path = ReducerKit/ReducerKit.xcodeproj; sourceTree = "<group>"; };
+		57664F682DF03A9000CA8D68 /* Mark-In-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Mark-In-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		57AC52EF2DA4FBC900BA84BD /* DesignSystem.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DesignSystem.xcodeproj; path = DesignSystem/DesignSystem.xcodeproj; sourceTree = "<group>"; };
 		57AC53092DA4FC1800BA84BD /* Util.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Util.xcodeproj; path = Util/Util.xcodeproj; sourceTree = "<group>"; };
 		57AC53232DA4FC4900BA84BD /* LinkMetadataKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = LinkMetadataKit.xcodeproj; path = LinkMetadataKit/LinkMetadataKit.xcodeproj; sourceTree = "<group>"; };
@@ -112,6 +120,11 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		57664F692DF03A9000CA8D68 /* Mark-In-Tests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "Mark-In-Tests";
+			sourceTree = "<group>";
+		};
 		57BFD8C52DA4E19600648AD4 /* Mark-In */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -123,6 +136,13 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		57664F652DF03A9000CA8D68 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		57BFD8C02DA4E19600648AD4 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -217,6 +237,7 @@
 				57AC56602DA511AF00BA84BD /* Shared */,
 				57AC565F2DA511A900BA84BD /* Core */,
 				57BFD8C52DA4E19600648AD4 /* Mark-In */,
+				57664F692DF03A9000CA8D68 /* Mark-In-Tests */,
 				57AC55422DA507EC00BA84BD /* Frameworks */,
 				57BFD8C42DA4E19600648AD4 /* Products */,
 			);
@@ -228,6 +249,7 @@
 			isa = PBXGroup;
 			children = (
 				57BFD8C32DA4E19600648AD4 /* Mark-In.app */,
+				57664F682DF03A9000CA8D68 /* Mark-In-Tests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -235,6 +257,29 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		57664F672DF03A9000CA8D68 /* Mark-In-Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 57664F6E2DF03A9000CA8D68 /* Build configuration list for PBXNativeTarget "Mark-In-Tests" */;
+			buildPhases = (
+				57664F642DF03A9000CA8D68 /* Sources */,
+				57664F652DF03A9000CA8D68 /* Frameworks */,
+				57664F662DF03A9000CA8D68 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				57664F6D2DF03A9000CA8D68 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				57664F692DF03A9000CA8D68 /* Mark-In-Tests */,
+			);
+			name = "Mark-In-Tests";
+			packageProductDependencies = (
+			);
+			productName = "Mark-In-Tests";
+			productReference = 57664F682DF03A9000CA8D68 /* Mark-In-Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		57BFD8C22DA4E19600648AD4 /* Mark-In */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 57BFD8CF2DA4E19700648AD4 /* Build configuration list for PBXNativeTarget "Mark-In" */;
@@ -270,9 +315,13 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1630;
+				LastSwiftUpdateCheck = 1640;
 				LastUpgradeCheck = 1640;
 				TargetAttributes = {
+					57664F672DF03A9000CA8D68 = {
+						CreatedOnToolsVersion = 16.4;
+						TestTargetID = 57BFD8C22DA4E19600648AD4;
+					};
 					57BFD8C22DA4E19600648AD4 = {
 						CreatedOnToolsVersion = 16.3;
 					};
@@ -319,6 +368,7 @@
 			projectRoot = "";
 			targets = (
 				57BFD8C22DA4E19600648AD4 /* Mark-In */,
+				57664F672DF03A9000CA8D68 /* Mark-In-Tests */,
 			);
 		};
 /* End PBXProject section */
@@ -369,6 +419,13 @@
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
+		57664F662DF03A9000CA8D68 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		57BFD8C12DA4E19600648AD4 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -379,6 +436,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		57664F642DF03A9000CA8D68 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		57BFD8BF2DA4E19600648AD4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -388,7 +452,61 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		57664F6D2DF03A9000CA8D68 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 57BFD8C22DA4E19600648AD4 /* Mark-In */;
+			targetProxy = 57664F6C2DF03A9000CA8D68 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		57664F6F2DF03A9000CA8D68 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5DFZR8RCQR;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				MACOSX_DEPLOYMENT_TARGET = 15.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "kr.co.ios.swift.apple.Mark-In-Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Mark-In.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Mark-In";
+				XROS_DEPLOYMENT_TARGET = 2.5;
+			};
+			name = Debug;
+		};
+		57664F702DF03A9000CA8D68 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5DFZR8RCQR;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				MACOSX_DEPLOYMENT_TARGET = 15.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "kr.co.ios.swift.apple.Mark-In-Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Mark-In.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Mark-In";
+				XROS_DEPLOYMENT_TARGET = 2.5;
+			};
+			name = Release;
+		};
 		57BFD8CD2DA4E19700648AD4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 57BFD8C52DA4E19600648AD4 /* Mark-In */;
@@ -598,6 +716,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		57664F6E2DF03A9000CA8D68 /* Build configuration list for PBXNativeTarget "Mark-In-Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57664F6F2DF03A9000CA8D68 /* Debug */,
+				57664F702DF03A9000CA8D68 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		57BFD8BE2DA4E19600648AD4 /* Build configuration list for PBXProject "Mark-In" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Mark-In.xcodeproj/xcshareddata/xcschemes/Mark-In.xcscheme
+++ b/Mark-In.xcodeproj/xcshareddata/xcschemes/Mark-In.xcscheme
@@ -29,6 +29,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "57664F672DF03A9000CA8D68"
+               BuildableName = "Mark-In-Tests.xctest"
+               BlueprintName = "Mark-In-Tests"
+               ReferencedContainer = "container:Mark-In.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Release"

--- a/Mark-In.xcodeproj/xcshareddata/xcschemes/[Dev] Mark-In.xcscheme
+++ b/Mark-In.xcodeproj/xcshareddata/xcschemes/[Dev] Mark-In.xcscheme
@@ -29,6 +29,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "57664F672DF03A9000CA8D68"
+               BuildableName = "Mark-In-Tests.xctest"
+               BlueprintName = "Mark-In-Tests"
+               ReferencedContainer = "container:Mark-In.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Shared/TestSupport/TestSupport.xcodeproj/project.pbxproj
+++ b/Shared/TestSupport/TestSupport.xcodeproj/project.pbxproj
@@ -1,0 +1,376 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXFileReference section */
+		57664FA72DF2BF5800CA8D68 /* TestSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TestSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		57664FA92DF2BF5800CA8D68 /* TestSupport */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = TestSupport;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		57664FA42DF2BF5800CA8D68 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		57664F9D2DF2BF5800CA8D68 = {
+			isa = PBXGroup;
+			children = (
+				57664FA92DF2BF5800CA8D68 /* TestSupport */,
+				57664FA82DF2BF5800CA8D68 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		57664FA82DF2BF5800CA8D68 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				57664FA72DF2BF5800CA8D68 /* TestSupport.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		57664FA22DF2BF5800CA8D68 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		57664FA62DF2BF5800CA8D68 /* TestSupport */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 57664FAE2DF2BF5800CA8D68 /* Build configuration list for PBXNativeTarget "TestSupport" */;
+			buildPhases = (
+				57664FA22DF2BF5800CA8D68 /* Headers */,
+				57664FA32DF2BF5800CA8D68 /* Sources */,
+				57664FA42DF2BF5800CA8D68 /* Frameworks */,
+				57664FA52DF2BF5800CA8D68 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				57664FA92DF2BF5800CA8D68 /* TestSupport */,
+			);
+			name = TestSupport;
+			packageProductDependencies = (
+			);
+			productName = TestSupport;
+			productReference = 57664FA72DF2BF5800CA8D68 /* TestSupport.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		57664F9E2DF2BF5800CA8D68 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1640;
+				LastUpgradeCheck = 1640;
+				TargetAttributes = {
+					57664FA62DF2BF5800CA8D68 = {
+						CreatedOnToolsVersion = 16.4;
+						LastSwiftMigration = 1640;
+					};
+				};
+			};
+			buildConfigurationList = 57664FA12DF2BF5800CA8D68 /* Build configuration list for PBXProject "TestSupport" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 57664F9D2DF2BF5800CA8D68;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 57664FA82DF2BF5800CA8D68 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				57664FA62DF2BF5800CA8D68 /* TestSupport */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		57664FA52DF2BF5800CA8D68 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		57664FA32DF2BF5800CA8D68 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		57664FAC2DF2BF5800CA8D68 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 5DFZR8RCQR;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		57664FAD2DF2BF5800CA8D68 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 5DFZR8RCQR;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		57664FAF2DF2BF5800CA8D68 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = NO;
+				DEVELOPMENT_TEAM = 5DFZR8RCQR;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				ENABLE_TESTABILITY = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = kr.co.ios.swift.apple.TestSupport;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_MODULE = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				XROS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		57664FB02DF2BF5800CA8D68 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = NO;
+				DEVELOPMENT_TEAM = 5DFZR8RCQR;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = kr.co.ios.swift.apple.TestSupport;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_MODULE = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				XROS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		57664FA12DF2BF5800CA8D68 /* Build configuration list for PBXProject "TestSupport" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57664FAC2DF2BF5800CA8D68 /* Debug */,
+				57664FAD2DF2BF5800CA8D68 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		57664FAE2DF2BF5800CA8D68 /* Build configuration list for PBXNativeTarget "TestSupport" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57664FAF2DF2BF5800CA8D68 /* Debug */,
+				57664FB02DF2BF5800CA8D68 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 57664F9E2DF2BF5800CA8D68 /* Project object */;
+}

--- a/Shared/TestSupport/TestSupport/BaseTestCase.swift
+++ b/Shared/TestSupport/TestSupport/BaseTestCase.swift
@@ -1,0 +1,34 @@
+//
+//  BaseTestCase.swift
+//  TestSupport
+//
+//  Created by 이정동 on 6/6/25.
+//
+
+import Foundation
+
+public protocol BaseTestCase {
+  /// 초기에 주입받아야 할 데이터를 지정합니다
+  func given(_ task: () -> Void)
+  
+  /// 발생해야 할 이벤트, 또는 메소드 호출등을 실행시킵니다
+  func when(_ task: () -> Void)
+  
+  /// 결과 값이 기대와 같은지 확인합니다
+  func then(_ task: () -> Void)
+}
+
+public extension BaseTestCase {
+  
+  func given(_ task: () -> Void) {
+    task()
+  }
+  
+  func when(_ task: () -> Void) {
+    task()
+  }
+  
+  func then(_ task: () -> Void) {
+    task()
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- 이슈 번호를 작성해 주세요 -->
<!-- ex) - close #1 -->
- close #52 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요(이미지 첨부 가능) --> 
DTO CodingKey와 FirestoreFieldKey 간 매핑 일치 여부 테스트 코드를 작성하였습니다.
이 과정에서 여러 모듈의 테스트 코드에서 재사용 가능한 코드를 위해 TestSupport라는 이름의 모듈을 구현했습니다.

## 🎨 스크린샷
<!-- UI 변경사항이 있는 경우 스크린샷을 첨부해 주세요. -->
<!-- img src "이부분에 gif파일 넣어주세요" -->

## 💬 추가 설명
<!-- 추가적으로 설명할 부분이 있다면 작성해 주세요 -->
### 1. 작업 의미
이 작업의 의미는 개발자의 실수로 CodingKey 케이스 값을 변경하거나, Firestore의 FieldKey 값을 변경하면서 발생할 수 있는 매핑 불일치를 대응하기 위함입니다.
다만, 테스트 코드를 실행해야만 일치 여부를 확인할 수 있다는 점, 즉 개발자가 디버깅 환경에서 빌드하는 과정에서는 일치 여부를 확인할 수 없다는 점이 완벽한 대응책은 아니라고 느껴지긴 합니다.

### 2. TestSupport 모듈 구현
[류성두님이 뱅크샐러드 블로그 글](https://blog.banksalad.com/tech/test-in-banksalad-ios-3/)을 참고하였습니다.
이를 참고하여 given, when, then의 메서드를 제공하는 BaseTestCase 프로토콜을 구현하였습니다.
이는 모든 테스트코드들이 각 단계별 작업을 더 명확히 나눠질 수 있도록 하면서 가독성을 높이기 위함입니다.
```swift
public protocol BaseTestCase {
  /// 초기에 주입받아야 할 데이터를 지정합니다
  func given(_ task: () -> Void)
  
  /// 발생해야 할 이벤트, 또는 메소드 호출등을 실행시킵니다
  func when(_ task: () -> Void)
  
  /// 결과 값이 기대와 같은지 확인합니다
  func then(_ task: () -> Void)
}

public extension BaseTestCase {
  func given(_ task: () -> Void) { task() }
  
  func when(_ task: () -> Void) { task() }
  
  func then(_ task: () -> Void) { task() }
}
```
실제 사용 예시는 아래와 같습니다.
```swift
struct AppTests: BaseTestCase {
  @Test func basicTest() async throws {
    given { // 초기에 주입받아야 할 데이터를 지정 }
    when { // 발생해야 할 이벤트, 또는 메소드 호출등을 실행 }
    then { // 결과 값이 기대와 같은지 확인 }
  }
}
```