### PR TITLE
[Test] DeleteFolderUseCase 테스트 코드 작성

### DIFF
--- a/Mark-In-Tests/UseCaseTests/DeleteFolderUseCaseTests.swift
+++ b/Mark-In-Tests/UseCaseTests/DeleteFolderUseCaseTests.swift
@@ -14,10 +14,29 @@ struct DeleteFolderUseCaseTests {
   @Test
   func test_includingChildren이_true면_링크들을_삭제한다() async throws {
     // Given: 준비
+    let userID = "testUser"
+    let folderID = "testFolderID"
+    
+    let stubAuthUserManager = StubAuthUserManager(userID: userID)
+    let fakeLinkRepo = FakeLinkRepository()
+      .withTestLinks(userID: userID, folderID: folderID, count: 5)
+    let fakeFolderRepo = FakeFolderRepository()
+      .withTestFolder(userID: userID, folderID: folderID)
+      .withTestFolders(userID: userID, count: 2)
+    
+    let sut = DeleteFolderUseCaseImpl(
+      authUserManager: stubAuthUserManager,
+      linkRepository: fakeLinkRepo,
+      folderRepository: fakeFolderRepo
+    )
     
     // When: 실행
+    _ = try await sut.execute(folderID: folderID, includingChildren: true)
     
     // Then: 검증
+    let links = fakeLinkRepo.data[userID]!
+    
+    #expect(links.filter { $0.folderID == folderID }.isEmpty)
     
     // TearDown: 해제
     
@@ -26,10 +45,30 @@ struct DeleteFolderUseCaseTests {
   @Test
   func test_includingChildren이_false면_링크들을_기본_폴더로_이동한다() async throws {
     // Given: 준비
+    let userID = "testUser"
+    let folderID = "testFolderID"
+    let defaultFolderID: String? = nil
+    
+    let stubAuthUserManager = StubAuthUserManager(userID: userID)
+    let fakeLinkRepo = FakeLinkRepository()
+      .withTestLinks(userID: userID, folderID: folderID, count: 5)
+    let fakeFolderRepo = FakeFolderRepository()
+      .withTestFolder(userID: userID, folderID: folderID)
+      .withTestFolder(userID: userID, folderID: defaultFolderID)
+    
+    let sut = DeleteFolderUseCaseImpl(
+      authUserManager: stubAuthUserManager,
+      linkRepository: fakeLinkRepo,
+      folderRepository: fakeFolderRepo
+    )
     
     // When: 실행
+    _ = try await sut.execute(folderID: folderID, includingChildren: false)
     
     // Then: 검증
+    let links = fakeLinkRepo.data[userID]!
+    
+    #expect(links.filter { $0.folderID == defaultFolderID }.count == 5)
     
     // TearDown: 해제
     
@@ -38,10 +77,28 @@ struct DeleteFolderUseCaseTests {
   @Test
   func test_folderID가_nil이면_폴더는_삭제되지_않는다() async throws {
     // Given: 준비
+    let userID = "testUser"
+    let folderID: String? = nil
+    
+    let stubAuthUserManager = StubAuthUserManager(userID: userID)
+    let fakeLinkRepo = FakeLinkRepository()
+      .withTestLinks(userID: userID, folderID: folderID, count: 5)
+    let fakeFolderRepo = FakeFolderRepository()
+      .withTestFolder(userID: userID, folderID: folderID)
+    
+    let sut = DeleteFolderUseCaseImpl(
+      authUserManager: stubAuthUserManager,
+      linkRepository: fakeLinkRepo,
+      folderRepository: fakeFolderRepo
+    )
     
     // When: 실행
+    _ = try await sut.execute(folderID: folderID, includingChildren: false)
     
     // Then: 검증
+    let folders = fakeFolderRepo.data[userID]!
+    
+    #expect(folders.contains { $0.id == folderID })
     
     // TearDown: 해제
     
@@ -50,10 +107,28 @@ struct DeleteFolderUseCaseTests {
   @Test
   func test_folderID가_존재하면_폴더를_삭제한다() async throws {
     // Given: 준비
+    let userID = "testUser"
+    let folderID = "testFolder"
+    
+    let stubAuthUserManager = StubAuthUserManager(userID: userID)
+    let fakeLinkRepo = FakeLinkRepository()
+      .withTestLinks(userID: userID, folderID: folderID, count: 5)
+    let fakeFolderRepo = FakeFolderRepository()
+      .withTestFolder(userID: userID, folderID: folderID)
+    
+    let sut = DeleteFolderUseCaseImpl(
+      authUserManager: stubAuthUserManager,
+      linkRepository: fakeLinkRepo,
+      folderRepository: fakeFolderRepo
+    )
     
     // When: 실행
+    _ = try await sut.execute(folderID: folderID, includingChildren: false)
     
     // Then: 검증
+    let folders = fakeFolderRepo.data[userID]!
+    
+    #expect(folders.contains { $0.id == folderID } == false)
     
     // TearDown: 해제
     

--- a/Mark-In-Tests/UseCaseTests/DeleteFolderUseCaseTests.swift
+++ b/Mark-In-Tests/UseCaseTests/DeleteFolderUseCaseTests.swift
@@ -1,0 +1,61 @@
+//
+//  DeleteFolderUseCaseTests.swift
+//  Mark-In-Tests
+//
+//  Created by 이정동 on 6/6/25.
+//
+
+import Testing
+
+@testable import Mark_In
+
+struct DeleteFolderUseCaseTests {
+
+  @Test
+  func test_includingChildren이_true면_링크들을_삭제한다() async throws {
+    // Given: 준비
+    
+    // When: 실행
+    
+    // Then: 검증
+    
+    // TearDown: 해제
+    
+  }
+
+  @Test
+  func test_includingChildren이_false면_링크들을_기본_폴더로_이동한다() async throws {
+    // Given: 준비
+    
+    // When: 실행
+    
+    // Then: 검증
+    
+    // TearDown: 해제
+    
+  }
+  
+  @Test
+  func test_folderID가_nil이면_폴더는_삭제되지_않는다() async throws {
+    // Given: 준비
+    
+    // When: 실행
+    
+    // Then: 검증
+    
+    // TearDown: 해제
+    
+  }
+  
+  @Test
+  func test_folderID가_존재하면_폴더를_삭제한다() async throws {
+    // Given: 준비
+    
+    // When: 실행
+    
+    // Then: 검증
+    
+    // TearDown: 해제
+    
+  }
+}

--- a/Mark-In-Tests/ValidationsTests/DTOFieldKeyMappingTests.swift
+++ b/Mark-In-Tests/ValidationsTests/DTOFieldKeyMappingTests.swift
@@ -11,14 +11,14 @@ import Testing
 struct DTOFieldKeyMappingTests {
   
   @Test
-  func testCodingKeys_shouldMatchFirestoreFieldKeys_inFolderDTO() async throws {
+  func test_FolderDTO의_CodingKey와_FirestoreFieldKey가_일치해야_한다() async throws {
     #expect(FolderDTO.CodingKeys.id.rawValue == FirestoreFieldKey.Folder.id)
     #expect(FolderDTO.CodingKeys.name.rawValue == FirestoreFieldKey.Folder.name)
     #expect(FolderDTO.CodingKeys.createdAt.rawValue == FirestoreFieldKey.Folder.createdAt)
   }
   
   @Test
-  func testCodingKeys_shouldMatchFirestoreFieldKeys_inWebLinkDTO() async throws {
+  func test_WebLinkDTO의_CodingKey와_FirestoreFieldKey가_일치해야_한다() async throws {
     #expect(WebLinkDTO.CodingKeys.id.rawValue == FirestoreFieldKey.Link.id)
     #expect(WebLinkDTO.CodingKeys.url.rawValue == FirestoreFieldKey.Link.url)
     #expect(WebLinkDTO.CodingKeys.title.rawValue == FirestoreFieldKey.Link.title)

--- a/Mark-In-Tests/ValidationsTests/DTOFieldKeyMappingTests.swift
+++ b/Mark-In-Tests/ValidationsTests/DTOFieldKeyMappingTests.swift
@@ -1,0 +1,32 @@
+//
+//  Mark_In_Tests.swift
+//  Mark-In-Tests
+//
+//  Created by 이정동 on 6/4/25.
+//
+
+import Testing
+@testable import Mark_In
+
+struct DTOFieldKeyMappingTests {
+  
+  @Test
+  func testCodingKeys_shouldMatchFirestoreFieldKeys_inFolderDTO() async throws {
+    #expect(FolderDTO.CodingKeys.id.rawValue == FirestoreFieldKey.Folder.id)
+    #expect(FolderDTO.CodingKeys.name.rawValue == FirestoreFieldKey.Folder.name)
+    #expect(FolderDTO.CodingKeys.createdAt.rawValue == FirestoreFieldKey.Folder.createdAt)
+  }
+  
+  @Test
+  func testCodingKeys_shouldMatchFirestoreFieldKeys_inWebLinkDTO() async throws {
+    #expect(WebLinkDTO.CodingKeys.id.rawValue == FirestoreFieldKey.Link.id)
+    #expect(WebLinkDTO.CodingKeys.url.rawValue == FirestoreFieldKey.Link.url)
+    #expect(WebLinkDTO.CodingKeys.title.rawValue == FirestoreFieldKey.Link.title)
+    #expect(WebLinkDTO.CodingKeys.thumbnailUrl.rawValue == FirestoreFieldKey.Link.thumbnailUrl)
+    #expect(WebLinkDTO.CodingKeys.faviconUrl.rawValue == FirestoreFieldKey.Link.faviconUrl)
+    #expect(WebLinkDTO.CodingKeys.isPinned.rawValue == FirestoreFieldKey.Link.isPinned)
+    #expect(WebLinkDTO.CodingKeys.createdAt.rawValue == FirestoreFieldKey.Link.createdAt)
+    #expect(WebLinkDTO.CodingKeys.lastAccessedAt.rawValue == FirestoreFieldKey.Link.lastAccessedAt)
+    #expect(WebLinkDTO.CodingKeys.folderID.rawValue == FirestoreFieldKey.Link.folderID)
+  }
+}

--- a/Mark-In-Tests/ValidationsTests/DTOFieldKeyMappingTests.swift
+++ b/Mark-In-Tests/ValidationsTests/DTOFieldKeyMappingTests.swift
@@ -12,13 +12,26 @@ struct DTOFieldKeyMappingTests {
   
   @Test
   func test_FolderDTO의_CodingKey와_FirestoreFieldKey가_일치해야_한다() async throws {
+    // Given: 준비
+    
+    // When: 실행
+    
+    // Then: 검증
     #expect(FolderDTO.CodingKeys.id.rawValue == FirestoreFieldKey.Folder.id)
     #expect(FolderDTO.CodingKeys.name.rawValue == FirestoreFieldKey.Folder.name)
     #expect(FolderDTO.CodingKeys.createdAt.rawValue == FirestoreFieldKey.Folder.createdAt)
+    
+    // TearDown: 해제
+    
   }
   
   @Test
   func test_WebLinkDTO의_CodingKey와_FirestoreFieldKey가_일치해야_한다() async throws {
+    // Given: 준비
+    
+    // When: 실행
+    
+    // Then: 검증
     #expect(WebLinkDTO.CodingKeys.id.rawValue == FirestoreFieldKey.Link.id)
     #expect(WebLinkDTO.CodingKeys.url.rawValue == FirestoreFieldKey.Link.url)
     #expect(WebLinkDTO.CodingKeys.title.rawValue == FirestoreFieldKey.Link.title)
@@ -28,5 +41,8 @@ struct DTOFieldKeyMappingTests {
     #expect(WebLinkDTO.CodingKeys.createdAt.rawValue == FirestoreFieldKey.Link.createdAt)
     #expect(WebLinkDTO.CodingKeys.lastAccessedAt.rawValue == FirestoreFieldKey.Link.lastAccessedAt)
     #expect(WebLinkDTO.CodingKeys.folderID.rawValue == FirestoreFieldKey.Link.folderID)
+    
+    // TearDown: 해제
+    
   }
 }

--- a/Mark-In.xcodeproj/project.pbxproj
+++ b/Mark-In.xcodeproj/project.pbxproj
@@ -62,6 +62,13 @@
 			remoteGlobalIDString = 57AC54A62DA503DE00BA84BD;
 			remoteInfo = LinkMetadataKitInterface;
 		};
+		57664F6C2DF03A9000CA8D68 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 57BFD8BB2DA4E19600648AD4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 57BFD8C22DA4E19600648AD4;
+			remoteInfo = "Mark-In";
+		};
 		57AC56722DA511E900BA84BD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 57AC53092DA4FC1800BA84BD /* Util.xcodeproj */;
@@ -93,6 +100,7 @@
 /* Begin PBXFileReference section */
 		57588CE42DD9B4D500DBD9A7 /* AppDI.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = AppDI.xcodeproj; path = AppDI/AppDI.xcodeproj; sourceTree = "<group>"; };
 		57606D652DD63B14005EBE3D /* ReducerKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ReducerKit.xcodeproj; path = ReducerKit/ReducerKit.xcodeproj; sourceTree = "<group>"; };
+		57664F682DF03A9000CA8D68 /* Mark-In-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Mark-In-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		57AC52EF2DA4FBC900BA84BD /* DesignSystem.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = DesignSystem.xcodeproj; path = DesignSystem/DesignSystem.xcodeproj; sourceTree = "<group>"; };
 		57AC53092DA4FC1800BA84BD /* Util.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Util.xcodeproj; path = Util/Util.xcodeproj; sourceTree = "<group>"; };
 		57AC53232DA4FC4900BA84BD /* LinkMetadataKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = LinkMetadataKit.xcodeproj; path = LinkMetadataKit/LinkMetadataKit.xcodeproj; sourceTree = "<group>"; };
@@ -112,6 +120,11 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		57664F692DF03A9000CA8D68 /* Mark-In-Tests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "Mark-In-Tests";
+			sourceTree = "<group>";
+		};
 		57BFD8C52DA4E19600648AD4 /* Mark-In */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -123,6 +136,13 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		57664F652DF03A9000CA8D68 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		57BFD8C02DA4E19600648AD4 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -217,6 +237,7 @@
 				57AC56602DA511AF00BA84BD /* Shared */,
 				57AC565F2DA511A900BA84BD /* Core */,
 				57BFD8C52DA4E19600648AD4 /* Mark-In */,
+				57664F692DF03A9000CA8D68 /* Mark-In-Tests */,
 				57AC55422DA507EC00BA84BD /* Frameworks */,
 				57BFD8C42DA4E19600648AD4 /* Products */,
 			);
@@ -228,6 +249,7 @@
 			isa = PBXGroup;
 			children = (
 				57BFD8C32DA4E19600648AD4 /* Mark-In.app */,
+				57664F682DF03A9000CA8D68 /* Mark-In-Tests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -235,6 +257,29 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		57664F672DF03A9000CA8D68 /* Mark-In-Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 57664F6E2DF03A9000CA8D68 /* Build configuration list for PBXNativeTarget "Mark-In-Tests" */;
+			buildPhases = (
+				57664F642DF03A9000CA8D68 /* Sources */,
+				57664F652DF03A9000CA8D68 /* Frameworks */,
+				57664F662DF03A9000CA8D68 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				57664F6D2DF03A9000CA8D68 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				57664F692DF03A9000CA8D68 /* Mark-In-Tests */,
+			);
+			name = "Mark-In-Tests";
+			packageProductDependencies = (
+			);
+			productName = "Mark-In-Tests";
+			productReference = 57664F682DF03A9000CA8D68 /* Mark-In-Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		57BFD8C22DA4E19600648AD4 /* Mark-In */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 57BFD8CF2DA4E19700648AD4 /* Build configuration list for PBXNativeTarget "Mark-In" */;
@@ -270,9 +315,13 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1630;
+				LastSwiftUpdateCheck = 1640;
 				LastUpgradeCheck = 1640;
 				TargetAttributes = {
+					57664F672DF03A9000CA8D68 = {
+						CreatedOnToolsVersion = 16.4;
+						TestTargetID = 57BFD8C22DA4E19600648AD4;
+					};
 					57BFD8C22DA4E19600648AD4 = {
 						CreatedOnToolsVersion = 16.3;
 					};
@@ -319,6 +368,7 @@
 			projectRoot = "";
 			targets = (
 				57BFD8C22DA4E19600648AD4 /* Mark-In */,
+				57664F672DF03A9000CA8D68 /* Mark-In-Tests */,
 			);
 		};
 /* End PBXProject section */
@@ -369,6 +419,13 @@
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
+		57664F662DF03A9000CA8D68 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		57BFD8C12DA4E19600648AD4 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -379,6 +436,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		57664F642DF03A9000CA8D68 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		57BFD8BF2DA4E19600648AD4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -388,7 +452,61 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		57664F6D2DF03A9000CA8D68 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 57BFD8C22DA4E19600648AD4 /* Mark-In */;
+			targetProxy = 57664F6C2DF03A9000CA8D68 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		57664F6F2DF03A9000CA8D68 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5DFZR8RCQR;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				MACOSX_DEPLOYMENT_TARGET = 15.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "kr.co.ios.swift.apple.Mark-In-Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Mark-In.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Mark-In";
+				XROS_DEPLOYMENT_TARGET = 2.5;
+			};
+			name = Debug;
+		};
+		57664F702DF03A9000CA8D68 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5DFZR8RCQR;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				MACOSX_DEPLOYMENT_TARGET = 15.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "kr.co.ios.swift.apple.Mark-In-Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Mark-In.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Mark-In";
+				XROS_DEPLOYMENT_TARGET = 2.5;
+			};
+			name = Release;
+		};
 		57BFD8CD2DA4E19700648AD4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 57BFD8C52DA4E19600648AD4 /* Mark-In */;
@@ -598,6 +716,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		57664F6E2DF03A9000CA8D68 /* Build configuration list for PBXNativeTarget "Mark-In-Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57664F6F2DF03A9000CA8D68 /* Debug */,
+				57664F702DF03A9000CA8D68 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		57BFD8BE2DA4E19600648AD4 /* Build configuration list for PBXProject "Mark-In" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Mark-In.xcodeproj/xcshareddata/xcschemes/Mark-In.xcscheme
+++ b/Mark-In.xcodeproj/xcshareddata/xcschemes/Mark-In.xcscheme
@@ -29,6 +29,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "57664F672DF03A9000CA8D68"
+               BuildableName = "Mark-In-Tests.xctest"
+               BlueprintName = "Mark-In-Tests"
+               ReferencedContainer = "container:Mark-In.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Release"

--- a/Mark-In.xcodeproj/xcshareddata/xcschemes/[Dev] Mark-In.xcscheme
+++ b/Mark-In.xcodeproj/xcshareddata/xcschemes/[Dev] Mark-In.xcscheme
@@ -29,6 +29,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "57664F672DF03A9000CA8D68"
+               BuildableName = "Mark-In-Tests.xctest"
+               BlueprintName = "Mark-In-Tests"
+               ReferencedContainer = "container:Mark-In.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Mark-In/Sources/App/AuthUserManager.swift
+++ b/Mark-In/Sources/App/AuthUserManager.swift
@@ -11,6 +11,10 @@ import Foundation
 
 import Util
 
+enum AuthError: Error {
+  case unauthenticated
+}
+
 struct AuthUser: Codable {
   let id: String
   let name: String
@@ -54,6 +58,19 @@ final class AuthUserManagerImpl: AuthUserManager {
   }
 }
 
-enum AuthError: Error {
-  case unauthenticated
+final class StubAuthUserManager: AuthUserManager {
+  var user: AuthUser?
+  
+  init(userID: String) {
+    self.user = .init(
+      id: userID,
+      name: userID,
+      email: "\(userID)@test.com",
+      provider: .apple
+    )
+  }
+  
+  func save(_ user: AuthUser) { }
+  func load() { }
+  func clear() { }
 }

--- a/Mark-In/Sources/Data/Tests/FakeFolderRepository.swift
+++ b/Mark-In/Sources/Data/Tests/FakeFolderRepository.swift
@@ -7,20 +7,53 @@
 
 import Foundation
 
-struct FakeFolderRepository: FolderRepository {
+final class FakeFolderRepository: FolderRepository {
+  var data: [String: [Folder]] = [:]
+  
   func create(userID: String, folder: WriteFolder) async throws -> Folder {
-    <#code#>
+    let folder = Folder(
+      id: UUID().uuidString,
+      name: folder.name,
+      createdAt: Date()
+    )
+    
+    data[userID, default: []].append(folder)
+    return folder
   }
   
   func fetchAll(userID: String) async throws -> [Folder] {
-    <#code#>
+    return data[userID] ?? []
   }
   
   func delete(userID: String, folderID: String) async throws {
-    <#code#>
+    data[userID]?.removeAll { $0.id == folderID }
   }
   
   func deleteAll(userID: String) async throws {
-    <#code#>
+    data[userID] = []
+  }
+}
+
+extension FakeFolderRepository {
+  func withTestFolders(userID: String, count: Int) -> Self {
+    let dummyFolders = (0..<count).map { _ in Folder.makeTestObject() }
+    data[userID, default: []].append(contentsOf: dummyFolders)
+    return self
+  }
+  
+  func withTestFolder(userID: String, folderID: String?) -> Self {
+    let dummyFolder = Folder.makeTestObject(id: folderID)
+    data[userID, default: []].append(dummyFolder)
+    return self
+  }
+}
+
+private extension Folder {
+  static func makeTestObject(
+    id: String? = UUID().uuidString,
+    name: String = "test-folder",
+    createdAt: Date = Date()
+  ) -> Folder {
+    Folder(id: id, name: name, createdAt: createdAt)
   }
 }

--- a/Mark-In/Sources/Data/Tests/FakeFolderRepository.swift
+++ b/Mark-In/Sources/Data/Tests/FakeFolderRepository.swift
@@ -1,0 +1,26 @@
+//
+//  MockFolderRepository.swift
+//  Mark-In
+//
+//  Created by 이정동 on 6/6/25.
+//
+
+import Foundation
+
+struct FakeFolderRepository: FolderRepository {
+  func create(userID: String, folder: WriteFolder) async throws -> Folder {
+    <#code#>
+  }
+  
+  func fetchAll(userID: String) async throws -> [Folder] {
+    <#code#>
+  }
+  
+  func delete(userID: String, folderID: String) async throws {
+    <#code#>
+  }
+  
+  func deleteAll(userID: String) async throws {
+    <#code#>
+  }
+}

--- a/Mark-In/Sources/Data/Tests/FakeLinkRepository.swift
+++ b/Mark-In/Sources/Data/Tests/FakeLinkRepository.swift
@@ -1,0 +1,40 @@
+//
+//  MockLinkRepository.swift
+//  Mark-In
+//
+//  Created by 이정동 on 6/6/25.
+//
+
+import Foundation
+
+final class FakeLinkRepository: LinkRepository {
+  func create(userID: String, link: WriteLink) async throws -> WebLink {
+    <#code#>
+  }
+  
+  func fetchAll(userID: String) async throws -> [WebLink] {
+    <#code#>
+  }
+  
+  func moveLinkInFolder(userID: String, target linkID: String, to folderID: String?) async throws {
+    <#code#>
+  }
+  
+  func moveLinksInFolder(userID: String, fromFolderID: String?, toFolderID: String?) async throws {
+    <#code#>
+  }
+  
+  func delete(userID: String, linkID: String) async throws {
+    <#code#>
+  }
+  
+  func deleteAllInFolder(userID: String, folderID: String?) async throws {
+    <#code#>
+  }
+  
+  func deleteAll(userID: String) async throws {
+    <#code#>
+  }
+  
+  
+}

--- a/Mark-In/Sources/Data/Tests/FakeLinkRepository.swift
+++ b/Mark-In/Sources/Data/Tests/FakeLinkRepository.swift
@@ -8,33 +8,110 @@
 import Foundation
 
 final class FakeLinkRepository: LinkRepository {
+  
+  var data: [String: [WebLink]] = [:]
+  
   func create(userID: String, link: WriteLink) async throws -> WebLink {
-    <#code#>
+    let webLink = WebLink(
+      id: UUID().uuidString,
+      url: link.url,
+      title: link.title,
+      thumbnailUrl: nil,
+      faviconUrl: nil,
+      isPinned: false,
+      createdAt: Date(),
+      lastAccessedAt: nil,
+      folderID: link.folderID
+    )
+    
+    data[userID, default: []].append(webLink)
+    
+    return webLink
   }
   
   func fetchAll(userID: String) async throws -> [WebLink] {
-    <#code#>
+    return data[userID] ?? []
   }
   
   func moveLinkInFolder(userID: String, target linkID: String, to folderID: String?) async throws {
-    <#code#>
+    let updated = data[userID]?.map {
+      $0.id == linkID ? $0.updating(folderID: folderID) : $0
+    }
+    
+    data[userID] = updated
   }
   
   func moveLinksInFolder(userID: String, fromFolderID: String?, toFolderID: String?) async throws {
-    <#code#>
+    let updated = data[userID]?.map {
+      $0.folderID == fromFolderID ? $0.updating(folderID: toFolderID) : $0
+    }
+    
+    data[userID] = updated
   }
   
   func delete(userID: String, linkID: String) async throws {
-    <#code#>
+    data[userID]?.removeAll { $0.id == linkID }
   }
   
   func deleteAllInFolder(userID: String, folderID: String?) async throws {
-    <#code#>
+    data[userID]?.removeAll { $0.folderID == folderID }
   }
   
   func deleteAll(userID: String) async throws {
-    <#code#>
+    data[userID] = []
+  }
+}
+
+extension FakeLinkRepository {
+  func withTestLinks(userID: String, folderID: String?, count: Int) -> Self {
+    let testLinks = (0..<count).map { _ in WebLink.makeTestObject(folderID: folderID) }
+    data[userID, default: []].append(contentsOf: testLinks)
+    return self
   }
   
+  func withTestLink(userID: String, linkID: String, folderID: String? = nil) -> Self {
+    let testLink = WebLink.makeTestObject(id: linkID, folderID: folderID)
+    data[userID, default: []].append(testLink)
+    return self
+  }
+}
+
+private extension WebLink {
+  static func makeTestObject(
+    id: String = UUID().uuidString,
+    url: String = "https://example.com",
+    title: String = "Test Link",
+    thumbnailUrl: String? = nil,
+    faviconUrl: String? = nil,
+    isPinned: Bool = false,
+    createdAt: Date = Date(),
+    lastAccessedAt: Date? = nil,
+    folderID: String? = "test-folder",
+  ) -> WebLink {
+    WebLink(
+      id: id,
+      url: url,
+      title: title,
+      thumbnailUrl: thumbnailUrl,
+      faviconUrl: faviconUrl,
+      isPinned: isPinned,
+      createdAt: createdAt,
+      lastAccessedAt: lastAccessedAt,
+      folderID: folderID
+    )
+  }
   
+  func updating(folderID: String?) -> WebLink {
+    WebLink(
+      id: id,
+      url: url,
+      title: title,
+      thumbnailUrl: thumbnailUrl,
+      faviconUrl: faviconUrl,
+      isPinned: isPinned,
+      createdAt: createdAt,
+      lastAccessedAt: lastAccessedAt,
+      folderID: folderID
+    )
+  }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- 이슈 번호를 작성해 주세요 -->
<!-- ex) - close #1 -->
- close #55 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요(이미지 첨부 가능) --> 
DeleteFolderUseCase에 대한 테스트 코드를 작성했습니다.
테스트 내용은 아래와 같습니다.
1. includingChildren이 true면 링크들을 삭제한다. (폴더 삭제 시 하위 링크 데이터까지 삭제한다.)
2. includingChildren이 false면 링크들을 기본 폴더로 이동한다. (폴더만 삭제 시 하위 링크들을 기본 폴더로 이동시킨다.)
3. folderID가 nil이면 폴더는 삭제되지 않는다. (삭제 대상이 기본 폴더일 경우, 폴더는 삭제되지 않는다.)
4. folderID가 존재하면 폴더를 삭제한다. (삭제 대상이 기본 폴더가 아닐 경우, 폴더는 삭제된다.)

## 🎨 스크린샷
<!-- UI 변경사항이 있는 경우 스크린샷을 첨부해 주세요. -->
<!-- img src "이부분에 gif파일 넣어주세요" -->

## 💬 추가 설명
<!-- 추가적으로 설명할 부분이 있다면 작성해 주세요 -->
